### PR TITLE
patch: retrait des balises `script`

### DIFF
--- a/src/Mail/Mail.php
+++ b/src/Mail/Mail.php
@@ -259,6 +259,8 @@ class Mail implements MailerInterface
      */
     public function html(string $content): static
     {
+		$content = preg_replace('/<script\b[^>]*>(.*?)<\/script>/is', '', $content);
+
         $this->factory()->html($content);
 
         return $this;


### PR DESCRIPTION
<!--

Chaque pull request doit traiter d’un seul problème et avoir un titre significatif.

- Les pull request doivent être en français.
- Si une pull request résout un problème, référencez le problème avec un mot-clé approprié (par exemple, fix <numéro de problème>).
- Toutes les corrections de bugs doivent être envoyées à la branche __"dev"__, c'est là que la prochaine version de correction de bug sera développée.
- Les PR avec toute amélioration doivent être envoyés à la branche de version mineure suivante, par ex. __"1.2"__

-->
**Description**
Supprime les balises <script> de contenu du message du mail.
En effet, en utilisant blitzphp-inertia (et zigot), le décorateur de vue de celui-ci injecte le code js nécessaire au routage coté front, et donc lors de l'envoie du mail, tout ce js est présent dans le contenu du mail envoyé. certes il ne s'exécute pas, mais il expose certaines valeurs

**Liste de contrôle:**
- [ ] Des commits signés en toute sécurité
- [ ] Composant(s) avec blocs PHPDoc, uniquement si nécessaire ou ajoute de la valeur
- [ ] Tests unitaires, avec une couverture > 80 %
- [ ] Guide de l'utilisateur mis à jour
- [ ] Conforme au guide de style
