### PR TITLE
feat: possibilité de definir plusieurs hotes pour une route

### DIFF
--- a/src/Router/RouteCollection.php
+++ b/src/Router/RouteCollection.php
@@ -1516,13 +1516,20 @@ class RouteCollection implements RouteCollectionInterface
     /**
      * Compare le nom d'hôte transmis avec le nom d'hôte actuel sur cette demande de page.
      *
-     * @param string $hostname Nom d'hôte dans les options d'itinéraire
+     * @param list<string>|string $hostname Nom d'hôte dans les options d'itinéraire
      */
-    private function checkHostname(string $hostname): bool
+    private function checkHostname(array|string $hostname): bool
     {
         // Les appels CLI ne peuvent pas être sur le nom d'hôte.
         if (! isset($this->httpHost)) {
             return false;
+        }
+
+        // hostname multiples
+        if (is_array($hostname)) {
+            $hostnameLower = array_map('strtolower', $hostname);
+
+            return in_array(strtolower($this->httpHost), $hostnameLower, true);
         }
 
         return strtolower($this->httpHost) === strtolower($hostname);


### PR DESCRIPTION
<!--

Chaque pull request doit traiter d’un seul problème et avoir un titre significatif.

- Les pull request doivent être en français.
- Si une pull request résout un problème, référencez le problème avec un mot-clé approprié (par exemple, fix <numéro de problème>).
- Toutes les corrections de bugs doivent être envoyées à la branche __"dev"__, c'est là que la prochaine version de correction de bug sera développée.
- Les PR avec toute amélioration doivent être envoyés à la branche de version mineure suivante, par ex. __"1.2"__

-->
**Description**
De cette façon, je peux définir une route pour plusieurs hôtes au lieu de créer plusieurs routes pour chaque nom d'hôte.


**Example**
 ```php
$routes->group('api', ['hostname' =>  ['api.website.com', 'api.website.net']], function ($routes) {
    $routes->get('/', 'Api::royplayer');
});
```

**Liste de contrôle:**
- [ ] Des commits signés en toute sécurité
- [ ] Composant(s) avec blocs PHPDoc, uniquement si nécessaire ou ajoute de la valeur
- [ ] Tests unitaires, avec une couverture > 80 %
- [ ] Guide de l'utilisateur mis à jour
- [ ] Conforme au guide de style
