### PR TITLE
feat: gestion des pages d'erreur en production

### DIFF
--- a/src/Debug/ExceptionManager.php
+++ b/src/Debug/ExceptionManager.php
@@ -55,6 +55,14 @@ class ExceptionManager
 
                 return Handler::QUIT;
             }
+            if (in_array('production', $files, true) && is_online()) {
+                $view = new View();
+                $view->setAdapter(config('view.active_adapter', 'native'), ['view_path_locator' => $config['error_view_path']])
+                    ->display('production')
+                    ->render();
+
+                return Handler::QUIT;
+            }
 
             return Handler::DONE;
         });

--- a/src/Translations/en/Errors.php
+++ b/src/Translations/en/Errors.php
@@ -1,0 +1,20 @@
+<?php
+
+/**
+ * This file is part of Blitz PHP framework.
+ *
+ * (c) 2022 Dimitri Sitchet Tomkeu <devcode.dst@gmail.com>
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+// Errors language settings
+return [
+    'pageNotFound'    => '404 - Page Not Found',
+    'sorryCannotFind' => 'Sorry! Cannot seem to find the page you were looking for.',
+    'badRequest'      => '400 - Bad Request',
+    'sorryBadRequest' => 'Sorry! Something is wrong with your request.',
+    'whoops'          => 'Whoops!',
+    'weHitASnag'      => 'We seem to have hit a snag. Please try again later...',
+];


### PR DESCRIPTION
<!--

Chaque pull request doit traiter d’un seul problème et avoir un titre significatif.

- Les pull request doivent être en français.
- Si une pull request résout un problème, référencez le problème avec un mot-clé approprié (par exemple, fix <numéro de problème>).
- Toutes les corrections de bugs doivent être envoyées à la branche __"dev"__, c'est là que la prochaine version de correction de bug sera développée.
- Les PR avec toute amélioration doivent être envoyés à la branche de version mineure suivante, par ex. __"1.2"__

-->
**Description**
Lorsqu'il y'avait une erreur en production, le navigateur renvoyait systématiquement du noir car l'affichage des erreur en prod est désactivée et aucun gestionnaire n'était défini pour gérer les erreurs de prod. 
Cette pull request introduit un gestionnaire d'erreur pour la prod 

***Avant***
![image](https://github.com/user-attachments/assets/14de6017-181c-4c36-82c9-814fa9629573)

***Apres***
![image](https://github.com/user-attachments/assets/cb83c51b-497d-4594-9966-66891288b509)


**Liste de contrôle:**
- [ ] Des commits signés en toute sécurité
- [ ] Composant(s) avec blocs PHPDoc, uniquement si nécessaire ou ajoute de la valeur
- [ ] Tests unitaires, avec une couverture > 80 %
- [ ] Guide de l'utilisateur mis à jour
- [x] Conforme au guide de style
