### PR TITLE
feat: ajout de l'option `namespace` à la commande `publish`

### DIFF
--- a/spec/system/framework/Publisher/PublisherSupport.spec.php
+++ b/spec/system/framework/Publisher/PublisherSupport.spec.php
@@ -31,8 +31,21 @@ describe('Publisher / PublisherSupport', function (): void {
 		expect($result[0])->toBeAnInstanceOf(TestPublisher::class);
 	});
 
-	it('Decouverte dans un dossiers non existant', function (): void {
+	it('Decouverte dans un dossier non existant', function (): void {
 		$result = Publisher::discover('Nothing');
+
+		expect($result)->toBe([]);
+	});
+
+	it('Decouverte dans un namespace', function (): void {
+		$result = Publisher::discover('Publishers', 'Spec\BlitzPHP\App');
+
+		expect($result)->toHaveLength(1);
+		expect($result[0])->toBeAnInstanceOf(TestPublisher::class);
+	});
+
+	it('Decouverte dans un namespace inexistants', function (): void {
+		$result = Publisher::discover('Publishers', 'Nothing\App');
 
 		expect($result)->toBe([]);
 	});

--- a/src/Cli/Commands/Utilities/Publish.php
+++ b/src/Cli/Commands/Utilities/Publish.php
@@ -36,12 +36,17 @@ class Publish extends Command
     protected $description = 'Découvre et exécute toutes les classes Publisher prédéfinies.';
 
     /**
-     * The Command's arguments
-     *
-     * @var array<string, string>
+     * {@inheritDoc}
      */
     protected $arguments = [
-        '[directory:Publishers]' => "[Facultatif] Le répertoire à analyser dans chaque espace de noms. Par défaut\u{a0}: \"Publishers\".",
+        '[directory:Publishers]' => 'Le répertoire à analyser dans chaque namespace.',
+    ];
+
+    /**
+     * {@inheritDoc}
+     */
+    protected $options = [
+        '-n|--namespace' => 'Le namespace à partir duquel on devra chercher les fichiers à publier. Par défaut, tous les namespaces sont analysés.',
     ];
 
     /**
@@ -49,10 +54,15 @@ class Publish extends Command
      */
     public function execute(array $params)
     {
-        $directory = array_shift($params) ?? 'Publishers';
+        $directory = $this->argument('directory', $params['directory'] ?? 'Publishers');
+        $namespace = $this->option('namespace', $params['namespace'] ?? '');
 
-        if ([] === $publishers = Publisher::discover($directory)) {
-            $this->write(lang('Publisher.publishMissing', [$directory]));
+        if ([] === $publishers = Publisher::discover($directory, $namespace)) {
+            if ($namespace === '') {
+                $this->write(lang('Publisher.publishMissing', [$directory]));
+            } else {
+                $this->write(lang('Publisher.publishMissingNamespace', [$directory, $namespace]));
+            }
 
             return;
         }

--- a/src/Publisher/Publisher.php
+++ b/src/Publisher/Publisher.php
@@ -90,17 +90,23 @@ class Publisher extends FileCollection
      *
      * @return list<self>
      */
-    final public static function discover(string $directory = 'Publishers'): array
+    final public static function discover(string $directory = 'Publishers', string $namespace = ''): array
     {
-        if (isset(self::$discovered[$directory])) {
-            return self::$discovered[$directory];
+        $key = implode('.', [$directory, $namespace]);
+
+        if (isset(self::$discovered[$key])) {
+            return self::$discovered[$key];
         }
 
-        self::$discovered[$directory] = [];
+        self::$discovered[$key] = [];
 
         $locator = Services::locator();
 
-        if ([] === $files = $locator->listFiles($directory)) {
+        $files = $namespace === ''
+            ? $locator->listFiles($directory)
+            : $locator->listNamespaceFiles($namespace, $directory);
+
+        if ([] === $files) {
             return [];
         }
 
@@ -109,13 +115,13 @@ class Publisher extends FileCollection
             $className = $locator->findQualifiedNameFromPath($file);
 
             if ($className !== false && class_exists($className) && is_a($className, self::class, true)) {
-                self::$discovered[$directory][] = Services::factory($className);
+                self::$discovered[$key][] = Services::factory($className);
             }
         }
 
-        sort(self::$discovered[$directory]);
+        sort(self::$discovered[$key]);
 
-        return self::$discovered[$directory];
+        return self::$discovered[$key];
     }
 
     /**

--- a/src/Translations/en/Publisher.php
+++ b/src/Translations/en/Publisher.php
@@ -16,7 +16,8 @@ return [
     'fileNotAllowed'        => '{0} fails the following restriction for {1}: {2}',
 
     // Publish Command
-    'publishMissing' => 'No Publisher classes detected in {0} across all namespaces.',
-    'publishSuccess' => '{0} published {1} file(s) to {2}.',
-    'publishFailure' => '{0} failed to publish to {1}!',
+    'publishMissing'          => 'No Publisher classes detected in {0} across all namespaces.',
+    'publishMissingNamespace' => 'No Publisher classes detected in {0} in namespace {1}.',
+    'publishSuccess'          => '{0} published {1} file(s) to {2}.',
+    'publishFailure'          => '{0} failed to publish to {1}!',
 ];


### PR DESCRIPTION
<!--

Chaque pull request doit traiter d’un seul problème et avoir un titre significatif.

- Les pull request doivent être en français.
- Si une pull request résout un problème, référencez le problème avec un mot-clé approprié (par exemple, fix <numéro de problème>).
- Toutes les corrections de bugs doivent être envoyées à la branche __"dev"__, c'est là que la prochaine version de correction de bug sera développée.
- Les PR avec toute amélioration doivent être envoyés à la branche de version mineure suivante, par ex. __"1.2"__

-->

**Description**
L'option `namespace` va permettre de définir le namespace à partir duquel on doit rechercher les publishers. ça permet non seulement de limiter les fichiers à scanner mais aussi empêche un publisher d'être réexécuter. 
En effet si une librairie a mal configuré son publisher, la réexécution peut entrainer un remplacement de fichier par exemple

**Liste de contrôle:**
- [ ] Des commits signés en toute sécurité
- [ ] Composant(s) avec blocs PHPDoc, uniquement si nécessaire ou ajoute de la valeur
- [x] Tests unitaires, avec une couverture > 80 %
- [ ] Guide de l'utilisateur mis à jour
- [x] Conforme au guide de style
