### PR TITLE
fix: correction du service de traduction pour prendre en charge la langue par défaut de l'app

### DIFF
--- a/src/Container/Services.php
+++ b/src/Container/Services.php
@@ -513,19 +513,15 @@ class Services
      */
     public static function translator(?string $locale = null, bool $shared = true): Translate
     {
-        if (($locale === null || $locale === '' || $locale === '0') && empty($locale = static::$instances[Translate::class . 'locale'] ?? null)) {
-            $config = static::config()->get('app');
-            if (($locale = static::negotiator()->language($config['supported_locales'])) === '' || ($locale = static::negotiator()->language($config['supported_locales'])) === '0') {
-                $locale = $config['language'];
-            }
-            static::$instances[Translate::class . 'locale'] = $locale;
-        }
+		if (null === $locale || $locale === '' || $locale === '0') {
+			$locale = static::request()->getLocale();
+		}
 
-        if (true === $shared && isset(static::$instances[Translate::class])) {
+		if (true === $shared && isset(static::$instances[Translate::class])) {
             return static::$instances[Translate::class]->setLocale($locale);
         }
 
-        return static::$instances[Translate::class] = new Translate($locale, static::locator());
+		return static::$instances[Translate::class] = new Translate($locale, static::locator());
     }
 
     /**

--- a/src/Http/ServerRequest.php
+++ b/src/Http/ServerRequest.php
@@ -1827,11 +1827,10 @@ class ServerRequest implements ServerRequestInterface
      */
     public function getLocale(): string
     {
-        $locale = $this->getAttribute('locale');
-        if (empty($locale)) {
+        if (empty($locale = $this->getAttribute('locale'))) {
             $locale = $this->getAttribute('lang');
         }
 
-        return $locale ?? Services::translator()->getLocale();
+        return $locale ?? config('app.language');
     }
 }


### PR DESCRIPTION
<!--

Chaque pull request doit traiter d’un seul problème et avoir un titre significatif.

- Les pull request doivent être en français.
- Si une pull request résout un problème, référencez le problème avec un mot-clé approprié (par exemple, fix <numéro de problème>).
- Toutes les corrections de bugs doivent être envoyées à la branche __"dev"__, c'est là que la prochaine version de correction de bug sera développée.
- Les PR avec toute amélioration doivent être envoyés à la branche de version mineure suivante, par ex. __"1.2"__

-->
**Description**
Tous les textes étaient systématiquement traduit avec la langue du navigateur, indépendamment des configurations relatives à la langue. 
Cette PR annule ce comportement. Désormais, pour prendre en compte la langue du navigateur, il faudra créer un middleware dédié.

```php
<?php

namespace App\Middlewares;

use BlitzPHP\Http\Request;
use BlitzPHP\Middlewares\BaseMiddleware;
use Psr\Http\Message\ResponseInterface;
use Psr\Http\Message\ServerRequestInterface;
use Psr\Http\Server\MiddlewareInterface;
use Psr\Http\Server\RequestHandlerInterface;

class LocalizerMiddleware extends BaseMiddleware implements MiddlewareInterface
{
    /**
     * @param Request $request
     */
    public function process(ServerRequestInterface $request, RequestHandlerInterface $handler): ResponseInterface
    {
        return $handler->handle(
			$request->withLocale($request->negotiate('language', config('app.supported_locales')))
		);
    }
}
```

**Liste de contrôle:**
- [ ] Des commits signés en toute sécurité
- [ ] Composant(s) avec blocs PHPDoc, uniquement si nécessaire ou ajoute de la valeur
- [ ] Tests unitaires, avec une couverture > 80 %
- [ ] Guide de l'utilisateur mis à jour
- [ ] Conforme au guide de style
