### PR TITLE
fix: correction du formattage XML via XmlFormatter

### DIFF
--- a/spec/system/framework/Formatter/XmlFormatter.spec.php
+++ b/spec/system/framework/Formatter/XmlFormatter.spec.php
@@ -1,0 +1,90 @@
+<?php
+
+/**
+ * This file is part of Blitz PHP framework.
+ *
+ * (c) 2022 Dimitri Sitchet Tomkeu <devcode.dst@gmail.com>
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+use BlitzPHP\Formatter\XmlFormatter;
+use BlitzPHP\Exceptions\FormatException;
+
+use function Kahlan\expect;
+
+describe('XmlFormatter', function() {
+    beforeEach(function() {
+        $this->formatter = new XmlFormatter();
+    });
+
+    describe('->format()', function() {
+        it('doit formater un simple tableau en XML', function() {
+            $data = ['name' => 'John', 'age' => 30];
+            $expected = "<?xml version=\"1.0\" encoding=\"utf-8\"?>\n<xml><name>John</name><age>30</age></xml>\n";
+            expect($this->formatter->format($data))->toBe($expected);
+        });
+
+        it('doit gérer les tableaux imbriqués', function() {
+            $data = ['person' => ['name' => 'John', 'age' => 30]];
+            $expected = "<?xml version=\"1.0\" encoding=\"utf-8\"?>\n<xml><person><name>John</name><age>30</age></person></xml>\n";
+            expect($this->formatter->format($data))->toBe($expected);
+        });
+
+        it('doit convertir les valeurs booleennes en entier', function() {
+            $data = ['active' => true, 'inactive' => false];
+            $expected = "<?xml version=\"1.0\" encoding=\"utf-8\"?>\n<xml><active>1</active><inactive>0</inactive></xml>\n";
+            expect($this->formatter->format($data))->toBe($expected);
+        });
+
+        it('doit gérer les clés numériques', function() {
+            $data = ['items' => [1, 2, 3]];
+            $expected = "<?xml version=\"1.0\" encoding=\"utf-8\"?>\n<xml><items><item>1</item><item>2</item><item>3</item></items></xml>\n";
+            expect($this->formatter->format($data))->toBe($expected);
+        });
+
+        it('doit gérer les attribues', function() {
+            $data = ['element' => ['_attributes' => ['id' => '1', 'class' => 'test'], 'value' => 'content']];
+            $expected = "<?xml version=\"1.0\" encoding=\"utf-8\"?>\n<xml><element id=\"1\" class=\"test\"><value>content</value></element></xml>\n";
+            expect($this->formatter->format($data))->toBe($expected);
+        });
+    });
+
+    describe('->parse()', function() {
+        it('doit analyser le XML et le convertir en un tableau', function() {
+            $xml = "<?xml version=\"1.0\" encoding=\"utf-8\"?><response><name>John</name><age>30</age></response>";
+            $expected = ['name' => 'John', 'age' => '30'];
+            expect($this->formatter->parse($xml))->toBe($expected);
+        });
+
+        it('doit gérer élements imbriqués', function() {
+            $xml = "<?xml version=\"1.0\" encoding=\"utf-8\"?><xml><person><name>John</name><age>30</age></person></xml>";
+            $expected = ['person' => ['name' => 'John', 'age' => '30']];
+            expect($this->formatter->parse($xml))->toBe($expected);
+        });
+
+        it('doit retourner un tableau vide pour les XML invalide', function() {
+            $xml = "This is not valid XML";
+            expect($this->formatter->parse($xml))->toBe([]);
+        });
+
+        it('doit gérer les attribues', function() {
+            $xml = "<?xml version=\"1.0\" encoding=\"utf-8\"?><xml><element id=\"1\" class=\"test\"><value>content</value></element></xml>";
+            $expected = ['element' => ['@attributes' => ['id' => '1', 'class' => 'test'], 'value' => 'content']];
+            expect($this->formatter->parse($xml))->toBe($expected);
+        });
+    });
+
+    describe('__construct()', function() {
+        xit('doit lever une exception FormatException si l\'extension simplexml n\'est pas chargée', function() {
+            allow('extension_loaded')->toBeCalled()->with('simplexml')->andReturn(false);
+
+            $closure = function() {
+                new XmlFormatter();
+            };
+
+            expect($closure)->toThrow(FormatException::missingExtension());
+        });
+    });
+});

--- a/src/Formatter/XmlFormatter.php
+++ b/src/Formatter/XmlFormatter.php
@@ -23,7 +23,7 @@ class XmlFormatter implements FormatterInterface
     {
         // SimpleXML est installé par défaut, mais il est préférable de vérifier, puis de fournir une solution de repli.
         if (! extension_loaded('simplexml')) {
-            throw FormatException::missingExtension(); // @codeCoverageIgnore
+            throw FormatException::missingExtension();
         }
 
         helper('inflector');
@@ -37,7 +37,7 @@ class XmlFormatter implements FormatterInterface
      */
     public function format($data)
     {
-        $basenode  = 'response';
+        $basenode  = 'xml';
         $structure = simplexml_load_string("<?xml version='1.0' encoding='utf-8'?><{$basenode} />");
 
         $this->arrayToXml((array) $data, $structure, $basenode);
@@ -52,7 +52,7 @@ class XmlFormatter implements FormatterInterface
      */
     public function parse(string $data): array
     {
-        $xml = simplexml_load_string($data, 'SimpleXMLElement', LIBXML_NOCDATA);
+        $xml = @simplexml_load_string($data, 'SimpleXMLElement', LIBXML_NOCDATA);
 
         if ($xml === false) {
             return [];

--- a/src/Formatter/XmlFormatter.php
+++ b/src/Formatter/XmlFormatter.php
@@ -11,6 +11,7 @@
 
 namespace BlitzPHP\Formatter;
 
+use BlitzPHP\Exceptions\FormatException;
 use SimpleXMLElement;
 
 /**
@@ -18,15 +19,15 @@ use SimpleXMLElement;
  */
 class XmlFormatter implements FormatterInterface
 {
-    /**
-     * @var string
-     */
-    protected $basenode = 'xml';
+    public function __construct()
+    {
+        // SimpleXML est installé par défaut, mais il est préférable de vérifier, puis de fournir une solution de repli.
+        if (! extension_loaded('simplexml')) {
+            throw FormatException::missingExtension(); // @codeCoverageIgnore
+        }
 
-    /**
-     * @var SimpleXMLElement
-     */
-    protected $structure;
+        helper('inflector');
+    }
 
     /**
      * {@inheritDoc}
@@ -36,15 +37,37 @@ class XmlFormatter implements FormatterInterface
      */
     public function format($data)
     {
-        if (empty($this->structure)) {
-            $this->structure = simplexml_load_string("<?xml version='1.0' encoding='utf-8'?><{$this->basenode} />");
+        $basenode  = 'response';
+        $structure = simplexml_load_string("<?xml version='1.0' encoding='utf-8'?><{$basenode} />");
+
+        $this->arrayToXml((array) $data, $structure, $basenode);
+
+        return $structure->asXML();
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @param string $data Chaine XML
+     */
+    public function parse(string $data): array
+    {
+        $xml = simplexml_load_string($data, 'SimpleXMLElement', LIBXML_NOCDATA);
+
+        if ($xml === false) {
+            return [];
         }
 
-        // Forcez-le à être quelque chose d'utile
-        if (! is_array($data) && ! is_object($data)) {
-            $data = (array) $data;
-        }
+        $json = json_encode($xml);
 
+        return json_decode($json, true);
+    }
+
+    /**
+     * Une méthode récursive pour convertir un tableau en une chaîne XML valide.
+     */
+    protected function arrayToXml(array $data, SimpleXMLElement &$structure, string $basenode): void
+    {
         foreach ($data as $key => $value) {
             // change false/true en 0/1
             if (is_bool($value)) {
@@ -53,9 +76,8 @@ class XmlFormatter implements FormatterInterface
 
             // pas de touches numériques dans notre xml s'il vous plait !
             if (is_numeric($key)) {
-                helper('inflector');
                 // crée une clé de chaîne...
-                $key = singular($this->basenode) !== $this->basenode ? singular($this->basenode) : 'item';
+                $key = singular($basenode) !== $basenode ? singular($basenode) : 'item';
             }
 
             // remplace tout ce qui n'est pas alphanumérique
@@ -68,35 +90,21 @@ class XmlFormatter implements FormatterInterface
                 }
 
                 foreach ($attributes as $attribute_name => $attribute_value) {
-                    $this->structure->addAttribute($attribute_name, $attribute_value);
+                    $structure->addAttribute($attribute_name, $attribute_value);
                 }
             }
             // s'il y a un autre tableau trouvé appelez récursivement cette fonction
             elseif (is_array($value) || is_object($value)) {
-                $node = $this->structure->addChild($key);
+                $node = $structure->addChild($key);
 
                 // appel récursif
-                $this->structure = $node;
-                $this->basenode  = $key;
-                $this->format($value);
+                $this->arrayToXml($value, $node, $key);
             } else {
                 // ajouter un seul noeud
-                $value = htmlspecialchars(html_entity_decode($value, ENT_QUOTES, 'UTF-8'), ENT_QUOTES, 'UTF-8');
+                $value = htmlspecialchars(html_entity_decode($value ?? '', ENT_QUOTES, 'UTF-8'), ENT_QUOTES, 'UTF-8');
 
-                $this->structure->addChild($key, $value);
+                $structure->addChild($key, $value);
             }
         }
-
-        return $this->structure->asXML();
-    }
-
-    /**
-     * {@inheritDoc}
-     *
-     * @param string $data Chaine XML
-     */
-    public function parse(string $data): array
-    {
-        return $data !== '' && $data !== '0' ? (array) simplexml_load_string($data, 'SimpleXMLElement', LIBXML_NOCDATA) : [];
     }
 }


### PR DESCRIPTION
<!--

Chaque pull request doit traiter d’un seul problème et avoir un titre significatif.

- Les pull request doivent être en français.
- Si une pull request résout un problème, référencez le problème avec un mot-clé approprié (par exemple, fix <numéro de problème>).
- Toutes les corrections de bugs doivent être envoyées à la branche __"dev"__, c'est là que la prochaine version de correction de bug sera développée.
- Les PR avec toute amélioration doivent être envoyés à la branche de version mineure suivante, par ex. __"1.2"__

-->
**Description**
Les tableau imbriqués n'étaient pas pris en compte. Ils étaient réduis à un tableau de dimension 1 lors de la sortie

Le tableau suivant 
```php
[
  'message' => 'index',
  'status' => true,
  'result' => [
    'file' => [
      'dir' => '__DIR__',
      'path' => '__FILE__',
      'line' => '__LINE__',
    ],
    'class' => [
        'namespace' => '__NAMESPACE__',
        'fqcn' => '__CLASS__',
        'method' => '__METHOD__',
    ]
  ],
]
```

génère 
```xml
<class>
  <namespace>__NAMESPACE__</namespace>
  <fqcn>__CLASS__</fqcn>
  <method>__METHOD__</method>
</class>
```

au lieu de
```xml
<message>index</message>
<status>1</status>
<result>
  <file>
    <dir>__DIR__</dir>
    <path>__FILE__</path>
    <line>__LINE__</line>
  </file>
  <class>
    <namespace>__NAMESPACE__</namespace>
    <class>__CLASS__</class>
    <method>__METHOD__</method>
  </class>
</result>
```

Par ailleurs, le parsing d'un XML valide en tableau PHP faisait systématiquement redémarrer le serveur de développement
 
**Liste de contrôle:**
- [ ] Des commits signés en toute sécurité
- [ ] Composant(s) avec blocs PHPDoc, uniquement si nécessaire ou ajoute de la valeur
- [ ] Tests unitaires, avec une couverture > 80 %
- [ ] Guide de l'utilisateur mis à jour
- [ ] Conforme au guide de style
