### PR TITLE
fix: concaténation de variable imbriqué dans le fichier .env

### DIFF
--- a/src/Helpers/common.php
+++ b/src/Helpers/common.php
@@ -44,7 +44,11 @@ if (! function_exists('env')) {
      */
     function env(string $key, $default = null)
     {
-        return Helpers::env($key, $default);
+        if (is_string($value = Helpers::env($key, $default)) && trim($value) === '') {
+            $value = $default;
+        }
+
+        return $value;
     }
 }
 


### PR DESCRIPTION
<!--

Chaque pull request doit traiter d’un seul problème et avoir un titre significatif.

- Les pull request doivent être en français.
- Si une pull request résout un problème, référencez le problème avec un mot-clé approprié (par exemple, fix <numéro de problème>).
- Toutes les corrections de bugs doivent être envoyées à la branche __"dev"__, c'est là que la prochaine version de correction de bug sera développée.
- Les PR avec toute amélioration doivent être envoyés à la branche de version mineure suivante, par ex. __"1.2"__

-->
**Description**
Il etait impossible d'utiliser une variable comme valeur d'une autre variable dans le fichier .env

par exemple;

```
app.name = "BlitzPHP App Skeleton"
mail.from.name = "${app.name}"
```

`env('mail.from.name')` renvoyait `${app.name}` au lieu de `BlitzPHP App Skeleton`.

Cette PR corrige ce comportement

**Liste de contrôle:**
- [ ] Des commits signés en toute sécurité
- [ ] Composant(s) avec blocs PHPDoc, uniquement si nécessaire ou ajoute de la valeur
- [ ] Tests unitaires, avec une couverture > 80 %
- [ ] Guide de l'utilisateur mis à jour
- [ ] Conforme au guide de style
