### PR TITLE
fix: contraint whoops a utiliser le code de l'exception comme code HTTP

### DIFF
--- a/src/Debug/ExceptionManager.php
+++ b/src/Debug/ExceptionManager.php
@@ -35,7 +35,12 @@ class ExceptionManager
     public static function registerHttpErrors(Run $debugger, array $config): Run
     {
         return $debugger->pushHandler(static function (Throwable $exception, InspectorInterface $inspector, RunInterface $run) use ($config): int {
-            if (true === $config['log'] && ! in_array($exception->getCode(), $config['ignore_codes'], true)) {
+            $exception_code = $exception->getCode();
+            if ($exception_code >= 400 && $exception_code < 600) {
+                $run->sendHttpCode($exception_code);
+            }
+
+			if (true === $config['log'] && ! in_array($exception->getCode(), $config['ignore_codes'], true)) {
                 service('logger')->error($exception);
             }
 

--- a/src/Debug/ExceptionManager.php
+++ b/src/Debug/ExceptionManager.php
@@ -40,7 +40,7 @@ class ExceptionManager
                 $run->sendHttpCode($exception_code);
             }
 
-			if (true === $config['log'] && ! in_array($exception->getCode(), $config['ignore_codes'], true)) {
+            if (true === $config['log'] && ! in_array($exception->getCode(), $config['ignore_codes'], true)) {
                 service('logger')->error($exception);
             }
 


### PR DESCRIPTION
<!--

Chaque pull request doit traiter d’un seul problème et avoir un titre significatif.

- Les pull request doivent être en français.
- Si une pull request résout un problème, référencez le problème avec un mot-clé approprié (par exemple, fix <numéro de problème>).
- Toutes les corrections de bugs doivent être envoyées à la branche __"dev"__, c'est là que la prochaine version de correction de bug sera développée.
- Les PR avec toute amélioration doivent être envoyés à la branche de version mineure suivante, par ex. __"1.2"__

-->
**Description**
ceci est notamment utile pour les pages d'erreurs personnalisées

une page d'erreur 404 renvoyait systématiquement un code HTTP 500 au lieu de 404

**Liste de contrôle:**
- [ ] Des commits signés en toute sécurité
- [ ] Composant(s) avec blocs PHPDoc, uniquement si nécessaire ou ajoute de la valeur
- [ ] Tests unitaires, avec une couverture > 80 %
- [ ] Guide de l'utilisateur mis à jour
- [ ] Conforme au guide de style
