### PR TITLE
patch: conversion automatique de la sortie binaire du chiffrement

### DIFF
--- a/src/Security/Encryption/Encryption.php
+++ b/src/Security/Encryption/Encryption.php
@@ -100,7 +100,7 @@ class Encryption implements EncrypterInterface
      */
     public function decrypt(string $data, array|string|null $params = null): string
     {
-        return $this->encrypter()->decrypt(base64_decode($data), $params);
+        return $this->encrypter()->decrypt(base64_decode($data, true), $params);
     }
 
     /**

--- a/src/Security/Encryption/Encryption.php
+++ b/src/Security/Encryption/Encryption.php
@@ -92,7 +92,7 @@ class Encryption implements EncrypterInterface
      */
     public function encrypt(string $data, array|string|null $params = null): string
     {
-        return $this->encrypter()->encrypt($data, $params);
+        return base64_encode($this->encrypter()->encrypt($data, $params));
     }
 
     /**
@@ -100,7 +100,7 @@ class Encryption implements EncrypterInterface
      */
     public function decrypt(string $data, array|string|null $params = null): string
     {
-        return $this->encrypter()->decrypt($data, $params);
+        return $this->encrypter()->decrypt(base64_decode($data), $params);
     }
 
     /**


### PR DESCRIPTION
<!--

Chaque pull request doit traiter d’un seul problème et avoir un titre significatif.

- Les pull request doivent être en français.
- Si une pull request résout un problème, référencez le problème avec un mot-clé approprié (par exemple, fix <numéro de problème>).
- Toutes les corrections de bugs doivent être envoyées à la branche __"dev"__, c'est là que la prochaine version de correction de bug sera développée.
- Les PR avec toute amélioration doivent être envoyés à la branche de version mineure suivante, par ex. __"1.2"__

-->
**Description**
Cette PR encode automatiquement les données binaires issues du chiffrement en chaine lisible. Ceci permet à l'utilisateur de ne pas le faire manuellement

Avant, on devais encoder la chaine chiffrée soit même pour pouvoir l'utiliser
```php
$encrypted = base64_encode(service('encrypter')->encrypt('text'));
```
maintenant l'encodage est automatiquement géré par le service de telle sorte que l'utilisateur n'ait plus à le faire
```php
$encrypted = service('encrypter')->encrypt('text');
```

Ce mecanisme est également valable pour le déchiffrement.

Notez que cette PR ne modifie pas les gestionnaire de chiffrement, seule la factorie a été touché. De ce fait, si vous utiliser directement une classe de chiffrement sans passer par le service, vous devriez continuer à encoder/decoder les resultats par vous même

**Liste de contrôle:**
- [ ] Des commits signés en toute sécurité
- [ ] Composant(s) avec blocs PHPDoc, uniquement si nécessaire ou ajoute de la valeur
- [ ] Tests unitaires, avec une couverture > 80 %
- [ ] Guide de l'utilisateur mis à jour
- [ ] Conforme au guide de style
