### PR TITLE
feat: possibilité pour un collector de definir son fichier de vue

### DIFF
--- a/src/Debug/Toolbar/Collectors/BaseCollector.php
+++ b/src/Debug/Toolbar/Collectors/BaseCollector.php
@@ -55,6 +55,11 @@ abstract class BaseCollector
     protected string $key = '';
 
     /**
+     * Le fichier de vue à utiliser pour rendre l'onglet du collector
+     */
+    protected string $view = '';
+
+    /**
      * Obtient le titre du collecteur
      */
     public function getTitle(bool $safe = false): string
@@ -76,6 +81,18 @@ abstract class BaseCollector
         }
 
         return str_replace(' ', '-', strtolower($this->key));
+    }
+
+    /**
+     * Obtient le fichier de vue à utiliser pour rendre l'onglet du collector
+     */
+    public function getView(): string
+    {
+        if ($this->view === '') {
+            $this->view = "_{$this->getKey()}.tpl";
+        }
+
+        return $this->view;
     }
 
     /**
@@ -218,6 +235,7 @@ abstract class BaseCollector
             'title'           => $this->getTitle(),
             'titleSafe'       => $this->getTitle(true),
             'key'             => $this->getKey(),
+            'view'            => $this->getView(),
             'titleDetails'    => $this->getTitleDetails(),
             'display'         => $this->display(),
             'badgeValue'      => $this->getBadgeValue(),

--- a/src/Debug/Toolbar/Views/toolbar.tpl.php
+++ b/src/Debug/Toolbar/Views/toolbar.tpl.php
@@ -111,7 +111,7 @@
                 <div id="blitzphp-<?= $c['key'] ?>" class="tab">
                     <h2><?= $c['title'] ?> <span><?= $c['titleDetails'] ?></span></h2>
 
-                    <?= is_string($c['display']) ? $c['display'] : $parser->setData($c['display'])->render("_{$c['key']}.tpl") ?>
+                    <?= is_string($c['display']) ? $c['display'] : $parser->setData($c['display'])->render($c['view']) ?>
                 </div>
             <?php endif ?>
         <?php endif ?>


### PR DESCRIPTION
<!--

Chaque pull request doit traiter d’un seul problème et avoir un titre significatif.

- Les pull request doivent être en français.
- Si une pull request résout un problème, référencez le problème avec un mot-clé approprié (par exemple, fix <numéro de problème>).
- Toutes les corrections de bugs doivent être envoyées à la branche __"dev"__, c'est là que la prochaine version de correction de bug sera développée.
- Les PR avec toute amélioration doivent être envoyés à la branche de version mineure suivante, par ex. __"1.2"__

-->
**Description**
Par défaut, les vues des collecteurs de la toolbar doivent être dans la dossier `Debug/Toolbar/Views`, or si une librairie tierce a des données complexes à afficher et qui nécessitent une vue, elle ne pourra pas. 
Cette PR donne la possibilité à un collecteur de définir un fichier de vue qui lui est propre

**Liste de contrôle:**
- [ ] Des commits signés en toute sécurité
- [ ] Composant(s) avec blocs PHPDoc, uniquement si nécessaire ou ajoute de la valeur
- [ ] Tests unitaires, avec une couverture > 80 %
- [ ] Guide de l'utilisateur mis à jour
- [ ] Conforme au guide de style
