### PR TITLE
patch: suppression des espaces dans le nom des logs

### DIFF
--- a/src/Debug/Logger.php
+++ b/src/Debug/Logger.php
@@ -68,7 +68,7 @@ class Logger implements LoggerInterface
     {
         $this->config = (object) config('log');
 
-        $this->monolog = new MonologLogger($this->config->name ?? 'application');
+        $this->monolog = new MonologLogger(str_replace(' ', '-', $this->config->name ?? 'application'));
 
         foreach (($this->config->handlers ?? []) as $handler => $options) {
             $this->pushHandler($handler, (object) $options);


### PR DESCRIPTION
<!--

Chaque pull request doit traiter d’un seul problème et avoir un titre significatif.

- Les pull request doivent être en français.
- Si une pull request résout un problème, référencez le problème avec un mot-clé approprié (par exemple, fix <numéro de problème>).
- Toutes les corrections de bugs doivent être envoyées à la branche __"dev"__, c'est là que la prochaine version de correction de bug sera développée.
- Les PR avec toute amélioration doivent être envoyés à la branche de version mineure suivante, par ex. __"1.2"__

-->
**Description**
Par défaut, si on est dans un environnement de test et que la session n'est pas bien configurée, le gestionnaire de session par défaut (File) lancera une warning `E_WARNING ini_set(): Session ini settings cannot be changed after headers have already been sent` ce qui fera échouer les tests. Voir https://github.com/dimtrovich/blitzphp-htmx/actions/runs/14934597431/job/41958911704

Ce commit bascule le gestionnaire File vers le gestionnaire Array lorsqu'on est dans un environnement de test et qu'aucune configuration du gestionnaire de session n'a été faite

**Liste de contrôle:**
- [ ] Des commits signés en toute sécurité
- [ ] Composant(s) avec blocs PHPDoc, uniquement si nécessaire ou ajoute de la valeur
- [ ] Tests unitaires, avec une couverture > 80 %
- [ ] Guide de l'utilisateur mis à jour
- [ ] Conforme au guide de style
